### PR TITLE
Fix Database connection smart cell cannot connect to IPv6 address

### DIFF
--- a/lib/kino_db/connection_cell.ex
+++ b/lib/kino_db/connection_cell.ex
@@ -240,7 +240,8 @@ defmodule KinoDB.ConnectionCell do
         port: unquote(attrs["port"]),
         username: unquote(attrs["username"]),
         password: unquote(attrs["password"]),
-        database: unquote(attrs["database"])
+        database: unquote(attrs["database"]),
+        socket_options: [:inet6]
       ]
     end
   end

--- a/test/kino_db/connection_cell_test.exs
+++ b/test/kino_db/connection_cell_test.exs
@@ -13,7 +13,15 @@ defmodule KinoDB.ConnectionCellTest do
 
       assert source ==
                """
-               opts = [hostname: "localhost", port: 5432, username: "", password: "", database: ""]
+               opts = [
+                 hostname: "localhost",
+                 port: 5432,
+                 username: "",
+                 password: "",
+                 database: "",
+                 socket_options: [:inet6]
+               ]
+
                {:ok, conn} = Kino.start_child({Postgrex, opts})\
                """
     end
@@ -38,7 +46,8 @@ defmodule KinoDB.ConnectionCellTest do
                  port: 4444,
                  username: "admin",
                  password: "pass",
-                 database: "default"
+                 database: "default",
+                 socket_options: [:inet6]
                ]
 
                {:ok, db} = Kino.start_child({MyXQL, opts})\
@@ -207,7 +216,15 @@ defmodule KinoDB.ConnectionCellTest do
     assert_broadcast_event(kino, "update", %{"fields" => %{"hostname" => "myhost"}})
 
     assert_smart_cell_update(kino, %{"hostname" => "myhost"}, """
-    opts = [hostname: "myhost", port: 5432, username: "", password: "", database: ""]
+    opts = [
+      hostname: "myhost",
+      port: 5432,
+      username: "",
+      password: "",
+      database: "",
+      socket_options: [:inet6]
+    ]
+
     {:ok, conn} = Kino.start_child({Postgrex, opts})\
     """)
   end
@@ -233,7 +250,15 @@ defmodule KinoDB.ConnectionCellTest do
     assert_broadcast_event(kino, "update", %{"fields" => %{"type" => "mysql", "port" => 3306}})
 
     assert_smart_cell_update(kino, %{"type" => "mysql", "port" => 3306}, """
-    opts = [hostname: "localhost", port: 3306, username: "", password: "", database: ""]
+    opts = [
+      hostname: "localhost",
+      port: 3306,
+      username: "",
+      password: "",
+      database: "",
+      socket_options: [:inet6]
+    ]
+
     {:ok, conn} = Kino.start_child({MyXQL, opts})\
     """)
   end


### PR DESCRIPTION
According to https://fly.io/docs/reference/postgres/#connecting-to-postgres-from-within-fly, Fly returns IPv6 addresses when querying its internal domain such as `elixir-notes-pg.internal`. 

I tried the fix in the Livebook app on both Fly and localhost with the following config and confirm they work well:

```elixir
Mix.install([
  {:kino_db, github: "goofansu/kino_db"},
  {:postgrex, "~> 0.16.3"}
])
```