### PR TITLE
Update SQLCell border to apply Dark Mode

### DIFF
--- a/lib/assets/sql_cell/main.css
+++ b/lib/assets/sql_cell/main.css
@@ -28,9 +28,11 @@ button {
   justify-content: flex-start;
   background-color: var(--blue-100);
   padding: 8px 16px;
-  border: solid 1px var(--gray-300);
-  border-radius: 0.5rem 0.5rem 0 0;
+  border-left: solid 1px var(--gray-300);
+  border-top: solid 1px var(--gray-300);
+  border-right: solid 1px var(--gray-300);
   border-bottom: solid 1px var(--gray-200);
+  border-radius: 0.5rem 0.5rem 0 0;
   gap: 16px;
 }
 


### PR DESCRIPTION
A tiny change so Dark Mode extensions can apply the dark mode color properly to the SQL Cell border

### Before

![image](https://user-images.githubusercontent.com/6402997/180858195-fc445601-6486-4956-af83-47001d6377f3.png)

### After

![image](https://user-images.githubusercontent.com/6402997/180858139-f779a717-40b4-4a2e-aa66-085846d5a462.png)