### PR TITLE
Correct help box text

### DIFF
--- a/lib/assets/sql_cell/main.js
+++ b/lib/assets/sql_cell/main.js
@@ -221,7 +221,7 @@ export function init(ctx, payload) {
           </button>
       </div>
       <ToggleBox id="help-box" class="section help-box" v-bind:toggle="isHelpBoxHidden">
-        <span>To dynamically inject values into the query use double curly braces, like {{name}}.</span>
+        <span v-pre>To dynamically inject values into the query use double curly braces, like {{name}}.</span>
       </ToggleBox>
       <ToggleBox id="settings-box" class="section help-box" v-bind:toggle="isSettingsBoxHidden">
         <div class="row mixed-row">


### PR DESCRIPTION
Noticed this tiny issue:
<img width="597" alt="image" src="https://user-images.githubusercontent.com/205390/186914462-186be49d-8cb6-44d3-8e88-5804b08190e6.png">

I know nothing about Vue but it turns out you need the [`v-pre` directive](https://vuejs.org/api/built-in-directives.html#v-pre) to skip compilation of `{{name}}` into an empty string.