### PR TITLE
Add sqlite to connection types supporting timeouts

### DIFF
--- a/lib/kino_db/sql_cell.ex
+++ b/lib/kino_db/sql_cell.ex
@@ -220,7 +220,7 @@ defmodule KinoDB.SQLCell do
     end
   end
 
-  @connection_types_with_timeout ~w|postgres mysql|
+  @connection_types_with_timeout ~w|postgres mysql sqlite|
 
   defp query_opts_args(%{"connection" => %{"type" => type}, "timeout" => timeout})
        when timeout != nil and type in @connection_types_with_timeout,

--- a/test/kino_db/sql_cell_test.exs
+++ b/test/kino_db/sql_cell_test.exs
@@ -300,7 +300,7 @@ defmodule KinoDB.SQLCellTest do
              """
 
       assert SQLCell.to_source(put_in(attrs["connection"]["type"], "sqlite")) == """
-             result = Exqlite.query!(conn, "SELECT id FROM users", [])\
+             result = Exqlite.query!(conn, "SELECT id FROM users", [], timeout: 30000)\
              """
 
       assert SQLCell.to_source(put_in(attrs["connection"]["type"], "bigquery")) == """


### PR DESCRIPTION
Not sure why this wasn't enabled to begin with, but I've been getting timeouts with longer running queries and this seems to do the trick 😄 