### PR TITLE
Add an explicit option for IPv6 to the db connection cell

### DIFF
--- a/lib/assets/connection_cell/main.css
+++ b/lib/assets/connection_cell/main.css
@@ -13,6 +13,7 @@
   --gray-800: #1c2a3a;
 
   --blue-100: #ecf0ff;
+  --blue-600: #3e64ff;
 
   --red-300: #f1a3a6;
 }
@@ -274,6 +275,60 @@ input::-webkit-inner-spin-button {
 
 .hidden-checkbox:hover {
   cursor: pointer;
+}
+
+/* Switch */
+
+.switch-button {
+  display: inline-block;
+  position: relative;
+  width: 56px;
+  height: 28px;
+  user-select: none;
+}
+
+.switch-button[disabled] {
+  pointer-events: none;
+  opacity: 0.5;
+}
+
+.switch-button-checkbox {
+  outline: none;
+  appearance: none;
+  position: absolute;
+  display: block;
+  width: 28px;
+  height: 28px;
+  margin: 0;
+  border-radius: 9999px;
+  background-color: var(--gray-400);
+  border: 5px solid var(--gray-100);
+  cursor: pointer;
+  transition-property: all;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 300ms;
+}
+
+.switch-button-bg {
+  display: block;
+  height: 100%;
+  width: 100%;
+  border-radius: 9999px;
+  background-color: var(--gray-100);
+  cursor: pointer;
+  transition-property: all;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 300ms;
+}
+
+.switch-button-checkbox:checked {
+  background: white;
+  border-color: var(--blue-600);
+  transform: translateX(100%);
+}
+
+.switch-button-checkbox:checked + .switch-button-bg {
+  background-color: var(--blue-600);
 }
 
 /* Fix icon position - Safari 11+ */

--- a/lib/assets/connection_cell/main.css
+++ b/lib/assets/connection_cell/main.css
@@ -34,7 +34,7 @@ button {
 
 .row {
   display: flex;
-  align-items: center;
+  flex-wrap: wrap;
   padding: 8px 16px;
   gap: 8px;
 }
@@ -124,6 +124,12 @@ input[required].empty {
   text-transform: uppercase;
 }
 
+.input-container {
+  flex-grow: 1;
+  display: flex;
+  align-items: center;
+}
+
 .field {
   display: flex;
   flex-direction: column;
@@ -186,15 +192,6 @@ select.input {
   background-position: center right 10px;
   background-size: 10px;
   padding-right: 28px;
-}
-
-@media only screen and (max-width: 750px) {
-  .mixed-row .field {
-    max-width: 32%;
-  }
-  .input--number {
-    max-width: 100%;
-  }
 }
 
 input::-webkit-outer-spin-button,

--- a/lib/assets/connection_cell/main.js
+++ b/lib/assets/connection_cell/main.js
@@ -157,17 +157,19 @@ export function init(ctx, info) {
       <label v-bind:class="inline ? 'inline-input-label' : 'input-label'">
         {{ label }}
       </label>
-      <label class="switch-button">
-        <input
-          :checked="modelValue"
-          type="checkbox"
-          @input="$emit('update:modelValue', $event.target.checked)"
-          v-bind="$attrs"
-          class="switch-button-checkbox"
-          v-bind:class="[inputClass, number ? 'input-number' : '']"
-        >
-        <div class="switch-button-bg" />
-      </label>
+      <div class="input-container">
+        <label class="switch-button">
+          <input
+            :checked="modelValue"
+            type="checkbox"
+            @input="$emit('update:modelValue', $event.target.checked)"
+            v-bind="$attrs"
+            class="switch-button-checkbox"
+            v-bind:class="[inputClass, number ? 'input-number' : '']"
+          >
+          <div class="switch-button-bg" />
+        </label>
+      </div>
     </div>
     `,
   };

--- a/lib/assets/connection_cell/main.js
+++ b/lib/assets/connection_cell/main.js
@@ -130,6 +130,48 @@ export function init(ctx, info) {
     `,
   };
 
+  const BaseSwitch = {
+    name: "BaseSwitch",
+
+    props: {
+      label: {
+        type: String,
+        default: "",
+      },
+      modelValue: {
+        type: Boolean,
+        default: true,
+      },
+      inline: {
+        type: Boolean,
+        default: false,
+      },
+      grow: {
+        type: Boolean,
+        default: false,
+      },
+    },
+
+    template: `
+    <div v-bind:class="[inline ? 'inline-field' : 'field', grow ? 'grow' : '']">
+      <label v-bind:class="inline ? 'inline-input-label' : 'input-label'">
+        {{ label }}
+      </label>
+      <label class="switch-button">
+        <input
+          :checked="modelValue"
+          type="checkbox"
+          @input="$emit('update:modelValue', $event.target.checked)"
+          v-bind="$attrs"
+          class="switch-button-checkbox"
+          v-bind:class="[inputClass, number ? 'input-number' : '']"
+        >
+        <div class="switch-button-bg" />
+      </label>
+    </div>
+    `,
+  };
+
   const SQLiteForm = {
     name: "SQLiteForm",
 
@@ -164,6 +206,7 @@ export function init(ctx, info) {
 
     components: {
       BaseInput: BaseInput,
+      BaseSwitch: BaseSwitch,
       BaseSelect: BaseSelect,
     },
 
@@ -219,6 +262,13 @@ export function init(ctx, info) {
         :grow
         :required
       />
+      <BaseSwitch
+        name="use_ipv6"
+        label="IPv6"
+        v-model="fields.use_ipv6"
+      />
+    </div>
+    <div class="row">
       <BaseInput
         name="database"
         label="Database"
@@ -227,8 +277,6 @@ export function init(ctx, info) {
         inputClass="input"
         :grow
       />
-    </div>
-    <div class="row">
       <BaseInput
         name="username"
         label="User"

--- a/lib/assets/sql_cell/main.css
+++ b/lib/assets/sql_cell/main.css
@@ -13,6 +13,7 @@
   --gray-800: #1c2a3a;
 
   --blue-100: #ecf0ff;
+  --blue-600: #3e64ff;
 }
 
 input,
@@ -210,64 +211,53 @@ select.input {
 /* Switch */
 
 .switch-button {
-  margin-top: 3px;
   display: inline-block;
-  height: 1.75rem;
-  margin-right: 0.5rem;
   position: relative;
-  transition-duration: 0.15s;
-  transition-property: color, background-color, border-color, fill, stroke,
-    opacity, box-shadow, transform, filter, -webkit-text-decoration-color,
-    -webkit-backdrop-filter;
-  transition-property: color, background-color, border-color,
-    text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter,
-    backdrop-filter;
-  transition-property: color, background-color, border-color,
-    text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter,
-    backdrop-filter, -webkit-text-decoration-color, -webkit-backdrop-filter;
-  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
+  width: 56px;
+  height: 28px;
   user-select: none;
-  width: 3.5rem;
 }
 
-.switch-checkbox {
-  -webkit-appearance: none;
-  -moz-appearance: none;
+.switch-button[disabled] {
+  pointer-events: none;
+  opacity: 0.5;
+}
+
+.switch-button-checkbox {
+  outline: none;
   appearance: none;
-  background-color: rgb(145 164 183);
-  border-color: rgb(240 245 249);
-  border-width: 5px;
-  height: 1.25rem;
   position: absolute;
-  width: 1.45rem;
-  top: 1px;
-}
-
-.switch-button-bg,
-.switch-checkbox {
-  border-radius: 9999px;
-  cursor: pointer;
   display: block;
-  transition-duration: 0.3s;
+  width: 28px;
+  height: 28px;
+  margin: 0;
+  border-radius: 9999px;
+  background-color: var(--gray-400);
+  border: 5px solid var(--gray-100);
+  cursor: pointer;
   transition-property: all;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 300ms;
 }
 
 .switch-button-bg {
-  background-color: var(--gray-200);
+  display: block;
   height: 100%;
   width: 100%;
+  border-radius: 9999px;
+  background-color: var(--gray-100);
+  cursor: pointer;
+  transition-property: all;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 300ms;
 }
 
-.switch-checkbox:checked {
-  background-color: rgb(255 255 255);
-  border-color: rgb(62 100 255);
+.switch-button-checkbox:checked {
+  background: white;
+  border-color: var(--blue-600);
   transform: translateX(100%);
 }
 
-.switch-checkbox:checked + .switch-button-bg {
-  background-color: rgb(62 100 255);
+.switch-button-checkbox:checked + .switch-button-bg {
+  background-color: var(--blue-600);
 }

--- a/lib/assets/sql_cell/main.css
+++ b/lib/assets/sql_cell/main.css
@@ -25,6 +25,7 @@ button {
 
 .header {
   display: flex;
+  flex-wrap: wrap;
   align-items: stretch;
   justify-content: flex-start;
   background-color: var(--blue-100);
@@ -79,6 +80,12 @@ button {
   padding-right: 6px;
   font-size: 0.875rem;
   text-transform: uppercase;
+}
+
+.input-container {
+  flex-grow: 1;
+  display: flex;
+  align-items: center;
 }
 
 .field {

--- a/lib/assets/sql_cell/main.js
+++ b/lib/assets/sql_cell/main.js
@@ -143,17 +143,19 @@ export function init(ctx, payload) {
       <label v-bind:class="inline ? 'inline-input-label' : 'input-label'">
         {{ label }}
       </label>
-      <label class="switch-button">
-        <input
-          :checked="modelValue"
-          type="checkbox"
-          @input="$emit('update:modelValue', $event.target.checked)"
-          v-bind="$attrs"
-          class="switch-button-checkbox"
-          v-bind:class="[inputClass, number ? 'input-number' : '']"
-        >
-        <div class="switch-button-bg" />
-      </label>
+      <div class="input-container">
+        <label class="switch-button">
+          <input
+            :checked="modelValue"
+            type="checkbox"
+            @input="$emit('update:modelValue', $event.target.checked)"
+            v-bind="$attrs"
+            class="switch-button-checkbox"
+            v-bind:class="[inputClass, number ? 'input-number' : '']"
+          >
+          <div class="switch-button-bg" />
+        </label>
+      </div>
     </div>
     `,
   };

--- a/lib/assets/sql_cell/main.js
+++ b/lib/assets/sql_cell/main.js
@@ -147,9 +147,9 @@ export function init(ctx, payload) {
         <input
           :checked="modelValue"
           type="checkbox"
-          @input="$emit('update:data', $event.target.checked)"
+          @input="$emit('update:modelValue', $event.target.checked)"
           v-bind="$attrs"
-          class="switch-checkbox"
+          class="switch-button-checkbox"
           v-bind:class="[inputClass, number ? 'input-number' : '']"
         >
         <div class="switch-button-bg" />

--- a/lib/kino_db/connection_cell.ex
+++ b/lib/kino_db/connection_cell.ex
@@ -23,6 +23,7 @@ defmodule KinoDB.ConnectionCell do
       "hostname" => attrs["hostname"] || "localhost",
       "database_path" => attrs["database_path"] || "",
       "port" => attrs["port"] || default_port,
+      "use_ipv6" => false,
       "username" => attrs["username"] || "",
       "password" => password,
       "use_password_secret" => Map.has_key?(attrs, "password_secret") || password == "",
@@ -130,8 +131,8 @@ defmodule KinoDB.ConnectionCell do
 
         type when type in ["postgres", "mysql"] ->
           if fields["use_password_secret"],
-            do: ~w|database hostname port username password_secret|,
-            else: ~w|database hostname port username password|
+            do: ~w|database hostname port use_ipv6 username password_secret|,
+            else: ~w|database hostname port use_ipv6 username password|
       end
 
     Map.take(fields, @default_keys ++ connection_keys)
@@ -289,15 +290,18 @@ defmodule KinoDB.ConnectionCell do
   end
 
   defp shared_options(attrs) do
-    quote do
-      [
-        hostname: unquote(attrs["hostname"]),
-        port: unquote(attrs["port"]),
-        username: unquote(attrs["username"]),
-        password: unquote(quoted_pass(attrs)),
-        database: unquote(attrs["database"]),
-        socket_options: [:inet6]
-      ]
+    opts = [
+      hostname: attrs["hostname"],
+      port: attrs["port"],
+      username: attrs["username"],
+      password: quoted_pass(attrs),
+      database: attrs["database"]
+    ]
+
+    if attrs["use_ipv6"] do
+      opts ++ [socket_options: [:inet6]]
+    else
+      opts ++ []
     end
   end
 

--- a/test/kino_db/connection_cell_test.exs
+++ b/test/kino_db/connection_cell_test.exs
@@ -12,6 +12,7 @@ defmodule KinoDB.ConnectionCellTest do
     "type" => "postgres",
     "hostname" => "localhost",
     "port" => 4444,
+    "use_ipv6" => false,
     "username" => "admin",
     "password" => "pass",
     "use_password_secret" => false,
@@ -49,15 +50,7 @@ defmodule KinoDB.ConnectionCellTest do
 
       assert source ==
                """
-               opts = [
-                 hostname: "localhost",
-                 port: 5432,
-                 username: "",
-                 password: "",
-                 database: "",
-                 socket_options: [:inet6]
-               ]
-
+               opts = [hostname: "localhost", port: 5432, username: "", password: "", database: ""]
                {:ok, conn} = Kino.start_child({Postgrex, opts})\
                """
     end
@@ -66,6 +59,20 @@ defmodule KinoDB.ConnectionCellTest do
   describe "code generation" do
     test "restores source code from attrs" do
       assert ConnectionCell.to_source(@attrs) === ~s'''
+             opts = [
+               hostname: "localhost",
+               port: 4444,
+               username: "admin",
+               password: "pass",
+               database: "default"
+             ]
+
+             {:ok, db} = Kino.start_child({Postgrex, opts})\
+             '''
+
+      attrs = Map.put(@attrs, "use_ipv6", true)
+
+      assert ConnectionCell.to_source(attrs) === ~s'''
              opts = [
                hostname: "localhost",
                port: 4444,
@@ -86,8 +93,7 @@ defmodule KinoDB.ConnectionCellTest do
                port: 4444,
                username: "admin",
                password: System.fetch_env!("LB_PASS"),
-               database: "default",
-               socket_options: [:inet6]
+               database: "default"
              ]
 
              {:ok, db} = Kino.start_child({Postgrex, opts})\
@@ -99,8 +105,7 @@ defmodule KinoDB.ConnectionCellTest do
                port: 4444,
                username: "admin",
                password: "pass",
-               database: "default",
-               socket_options: [:inet6]
+               database: "default"
              ]
 
              {:ok, db} = Kino.start_child({MyXQL, opts})\
@@ -182,15 +187,7 @@ defmodule KinoDB.ConnectionCellTest do
     assert_broadcast_event(kino, "update", %{"fields" => %{"hostname" => "myhost"}})
 
     assert_smart_cell_update(kino, %{"hostname" => "myhost"}, """
-    opts = [
-      hostname: "myhost",
-      port: 5432,
-      username: "",
-      password: "",
-      database: "",
-      socket_options: [:inet6]
-    ]
-
+    opts = [hostname: "myhost", port: 5432, username: "", password: "", database: ""]
     {:ok, conn} = Kino.start_child({Postgrex, opts})\
     """)
   end
@@ -216,15 +213,7 @@ defmodule KinoDB.ConnectionCellTest do
     assert_broadcast_event(kino, "update", %{"fields" => %{"type" => "mysql", "port" => 3306}})
 
     assert_smart_cell_update(kino, %{"type" => "mysql", "port" => 3306}, """
-    opts = [
-      hostname: "localhost",
-      port: 3306,
-      username: "",
-      password: "",
-      database: "",
-      socket_options: [:inet6]
-    ]
-
+    opts = [hostname: "localhost", port: 3306, username: "", password: "", database: ""]
     {:ok, conn} = Kino.start_child({MyXQL, opts})\
     """)
   end
@@ -252,8 +241,7 @@ defmodule KinoDB.ConnectionCellTest do
         port: 5432,
         username: "",
         password: System.fetch_env!("LB_PASS"),
-        database: "",
-        socket_options: [:inet6]
+        database: ""
       ]
 
       {:ok, conn} = Kino.start_child({Postgrex, opts})\


### PR DESCRIPTION
#26 added support for connecting to postrgres via IPv6, however with `socket_options: [:inet6]` we can no longer connect over IPv4, in particular to localhost. This adds a checkbox to opt-in for IPv6.

![image](https://user-images.githubusercontent.com/17034772/194442025-a81d5abf-4301-4d32-95bd-5d86ecea56a8.png)

Also some tiny styling fixes.