### PR TITLE
Exclude Mint.HTTP module from warnings

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -14,7 +14,8 @@ defmodule KinoDB.MixProject do
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       docs: docs(),
-      package: package()
+      package: package(),
+      xref: xref()
     ]
   end
 
@@ -53,6 +54,12 @@ defmodule KinoDB.MixProject do
       links: %{
         "GitHub" => "https://github.com/livebook-dev/kino_db"
       }
+    ]
+  end
+
+  def xref do
+    [
+      exclude: [Mint.HTTP]
     ]
   end
 end


### PR DESCRIPTION
```
==> kino_db
Compiling 4 files (.ex)
warning: Mint.HTTP.connect/3 is undefined (module Mint.HTTP is not available or is yet to be defined)
  lib/kino_db/connection_cell.ex:395: KinoDB.ConnectionCell.running_on_google_metadata?/0

warning: Mint.HTTP.set_mode/2 is undefined (module Mint.HTTP is not available or is yet to be defined)
  lib/kino_db/connection_cell.ex:396: KinoDB.ConnectionCell.running_on_google_metadata?/0

Generated kino_db app
```