### PR TITLE
Fix SQL cell error when there is no default connection

### DIFF
--- a/lib/assets/sql_cell/main.js
+++ b/lib/assets/sql_cell/main.js
@@ -57,7 +57,7 @@ export function init(ctx, payload) {
         :value="modelValue"
         v-bind="$attrs"
         v-bind:disabled="disabled"
-        @change="$emit('update:data', $event.target.value)"
+        @change="$emit('update:modelValue', $event.target.value)"
         v-bind:class="[selectClass, existent ? '' : 'nonexistent']"
       >
         <option
@@ -198,7 +198,7 @@ export function init(ctx, payload) {
               @change="handleConnectionChange"
               name="connection_variable"
               label="Query"
-              v-model="payload.connection.variable"
+              v-model="(payload.connection || {}).variable"
               selectClass="input input--xs"
               :existent="isConnectionExistent"
               :disabled="isConnectionDisabled"
@@ -272,11 +272,11 @@ export function init(ctx, payload) {
         const connection = this.payload.connection;
         const connections = this.payload.connections;
 
-        const availableConnection = connections.some(
-          (conn) => conn.variable === connection.variable
-        );
+        const availableConnection =
+          connection &&
+          connections.some((conn) => conn.variable === connection.variable);
 
-        if (this.connection === null) {
+        if (connection === null) {
           this.isConnectionExistent = false;
           this.isConnectionDisabled = true;
           return [];
@@ -336,7 +336,7 @@ export function init(ctx, payload) {
   });
 
   ctx.handleEvent("update_connection", (variable) => {
-    const connection = app.connections.find(
+    const connection = app.payload.connections.find(
       (conn) => conn.variable === variable
     );
     app.payload.connection = connection;


### PR DESCRIPTION
Currently inserting SQL cell into an empty notebook doesn't render the cell UI, because we miss some guards against no connection.