### PR TITLE
Add SSL support to connection cell

### DIFF
--- a/lib/assets/connection_cell/main.js
+++ b/lib/assets/connection_cell/main.js
@@ -349,6 +349,11 @@ export function init(ctx, info) {
         :required
       />
       <BaseSwitch
+        name="use_ssl"
+        label="SSL"
+        v-model="fields.use_ssl"
+      />
+      <BaseSwitch
         name="use_ipv6"
         label="IPv6"
         v-model="fields.use_ipv6"

--- a/lib/kino_db/connection_cell.ex
+++ b/lib/kino_db/connection_cell.ex
@@ -338,7 +338,7 @@ defmodule KinoDB.ConnectionCell do
 
   defp missing_dep(%{"type" => "postgres"}) do
     unless Code.ensure_loaded?(Postgrex) do
-      ~s/{:postgrex, "~> 0.16.3"}/
+      ~s/{:postgrex, "~> 0.17.3"}/
     end
   end
 

--- a/lib/kino_db/connection_cell.ex
+++ b/lib/kino_db/connection_cell.ex
@@ -198,7 +198,6 @@ defmodule KinoDB.ConnectionCell do
     quote do
       opts = unquote(shared_options(attrs))
 
-      if opts[:ssl] == true, do: :ssl.start()
       {:ok, unquote(quoted_var(attrs["variable"]))} = Kino.start_child({Postgrex, opts})
     end
   end
@@ -207,7 +206,6 @@ defmodule KinoDB.ConnectionCell do
     quote do
       opts = unquote(shared_options(attrs))
 
-      if opts[:ssl] == true, do: :ssl.start()
       {:ok, unquote(quoted_var(attrs["variable"]))} = Kino.start_child({MyXQL, opts})
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -28,7 +28,7 @@ defmodule KinoDB.MixProject do
     [
       {:kino, "~> 0.7"},
       {:table, "~> 0.1.2"},
-      {:postgrex, "~> 0.16.3 or ~> 0.17.3 or ~> 0.18", optional: true},
+      {:postgrex, "~> 0.17.3 or ~> 0.18", optional: true},
       {:exqlite, "~> 0.11", optional: true},
       {:myxql, "~> 0.6.2 or ~> 0.7", optional: true},
       {:db_connection, "~> 2.4.2", optional: true},

--- a/mix.exs
+++ b/mix.exs
@@ -28,7 +28,7 @@ defmodule KinoDB.MixProject do
     [
       {:kino, "~> 0.7"},
       {:table, "~> 0.1.2"},
-      {:postgrex, "~> 0.16.3 or ~> 0.17", optional: true},
+      {:postgrex, "~> 0.16.3 or ~> 0.17.3 or ~> 0.18", optional: true},
       {:exqlite, "~> 0.11", optional: true},
       {:myxql, "~> 0.6.2 or ~> 0.7", optional: true},
       {:db_connection, "~> 2.4.2", optional: true},

--- a/test/kino_db/connection_cell_test.exs
+++ b/test/kino_db/connection_cell_test.exs
@@ -13,6 +13,7 @@ defmodule KinoDB.ConnectionCellTest do
     "hostname" => "localhost",
     "port" => 4444,
     "use_ipv6" => false,
+    "use_ssl" => false,
     "username" => "admin",
     "password" => "pass",
     "use_password_secret" => false,
@@ -51,6 +52,11 @@ defmodule KinoDB.ConnectionCellTest do
       assert source ==
                """
                opts = [hostname: "localhost", port: 5432, username: "", password: "", database: ""]
+
+               if opts[:ssl] == true do
+                 :ssl.start()
+               end
+
                {:ok, conn} = Kino.start_child({Postgrex, opts})\
                """
     end
@@ -67,6 +73,10 @@ defmodule KinoDB.ConnectionCellTest do
                database: "default"
              ]
 
+             if opts[:ssl] == true do
+               :ssl.start()
+             end
+
              {:ok, db} = Kino.start_child({Postgrex, opts})\
              '''
 
@@ -82,6 +92,29 @@ defmodule KinoDB.ConnectionCellTest do
                socket_options: [:inet6]
              ]
 
+             if opts[:ssl] == true do
+               :ssl.start()
+             end
+
+             {:ok, db} = Kino.start_child({Postgrex, opts})\
+             '''
+
+      attrs = Map.put(@attrs, "use_ssl", true)
+
+      assert ConnectionCell.to_source(attrs) === ~s'''
+             opts = [
+               hostname: "localhost",
+               port: 4444,
+               username: "admin",
+               password: "pass",
+               database: "default",
+               ssl: true
+             ]
+
+             if opts[:ssl] == true do
+               :ssl.start()
+             end
+
              {:ok, db} = Kino.start_child({Postgrex, opts})\
              '''
 
@@ -96,6 +129,10 @@ defmodule KinoDB.ConnectionCellTest do
                database: "default"
              ]
 
+             if opts[:ssl] == true do
+               :ssl.start()
+             end
+
              {:ok, db} = Kino.start_child({Postgrex, opts})\
              '''
 
@@ -107,6 +144,10 @@ defmodule KinoDB.ConnectionCellTest do
                password: "pass",
                database: "default"
              ]
+
+             if opts[:ssl] == true do
+               :ssl.start()
+             end
 
              {:ok, db} = Kino.start_child({MyXQL, opts})\
              '''
@@ -188,6 +229,11 @@ defmodule KinoDB.ConnectionCellTest do
 
     assert_smart_cell_update(kino, %{"hostname" => "myhost"}, """
     opts = [hostname: "myhost", port: 5432, username: "", password: "", database: ""]
+
+    if opts[:ssl] == true do
+      :ssl.start()
+    end
+
     {:ok, conn} = Kino.start_child({Postgrex, opts})\
     """)
   end
@@ -214,6 +260,11 @@ defmodule KinoDB.ConnectionCellTest do
 
     assert_smart_cell_update(kino, %{"type" => "mysql", "port" => 3306}, """
     opts = [hostname: "localhost", port: 3306, username: "", password: "", database: ""]
+
+    if opts[:ssl] == true do
+      :ssl.start()
+    end
+
     {:ok, conn} = Kino.start_child({MyXQL, opts})\
     """)
   end
@@ -243,6 +294,10 @@ defmodule KinoDB.ConnectionCellTest do
         password: System.fetch_env!("LB_PASS"),
         database: ""
       ]
+
+      if opts[:ssl] == true do
+        :ssl.start()
+      end
 
       {:ok, conn} = Kino.start_child({Postgrex, opts})\
       """

--- a/test/kino_db/connection_cell_test.exs
+++ b/test/kino_db/connection_cell_test.exs
@@ -52,11 +52,6 @@ defmodule KinoDB.ConnectionCellTest do
       assert source ==
                """
                opts = [hostname: "localhost", port: 5432, username: "", password: "", database: ""]
-
-               if opts[:ssl] == true do
-                 :ssl.start()
-               end
-
                {:ok, conn} = Kino.start_child({Postgrex, opts})\
                """
     end
@@ -73,10 +68,6 @@ defmodule KinoDB.ConnectionCellTest do
                database: "default"
              ]
 
-             if opts[:ssl] == true do
-               :ssl.start()
-             end
-
              {:ok, db} = Kino.start_child({Postgrex, opts})\
              '''
 
@@ -91,10 +82,6 @@ defmodule KinoDB.ConnectionCellTest do
                database: "default",
                socket_options: [:inet6]
              ]
-
-             if opts[:ssl] == true do
-               :ssl.start()
-             end
 
              {:ok, db} = Kino.start_child({Postgrex, opts})\
              '''
@@ -111,10 +98,6 @@ defmodule KinoDB.ConnectionCellTest do
                ssl: true
              ]
 
-             if opts[:ssl] == true do
-               :ssl.start()
-             end
-
              {:ok, db} = Kino.start_child({Postgrex, opts})\
              '''
 
@@ -129,10 +112,6 @@ defmodule KinoDB.ConnectionCellTest do
                database: "default"
              ]
 
-             if opts[:ssl] == true do
-               :ssl.start()
-             end
-
              {:ok, db} = Kino.start_child({Postgrex, opts})\
              '''
 
@@ -144,10 +123,6 @@ defmodule KinoDB.ConnectionCellTest do
                password: "pass",
                database: "default"
              ]
-
-             if opts[:ssl] == true do
-               :ssl.start()
-             end
 
              {:ok, db} = Kino.start_child({MyXQL, opts})\
              '''
@@ -229,11 +204,6 @@ defmodule KinoDB.ConnectionCellTest do
 
     assert_smart_cell_update(kino, %{"hostname" => "myhost"}, """
     opts = [hostname: "myhost", port: 5432, username: "", password: "", database: ""]
-
-    if opts[:ssl] == true do
-      :ssl.start()
-    end
-
     {:ok, conn} = Kino.start_child({Postgrex, opts})\
     """)
   end
@@ -260,11 +230,6 @@ defmodule KinoDB.ConnectionCellTest do
 
     assert_smart_cell_update(kino, %{"type" => "mysql", "port" => 3306}, """
     opts = [hostname: "localhost", port: 3306, username: "", password: "", database: ""]
-
-    if opts[:ssl] == true do
-      :ssl.start()
-    end
-
     {:ok, conn} = Kino.start_child({MyXQL, opts})\
     """)
   end
@@ -294,10 +259,6 @@ defmodule KinoDB.ConnectionCellTest do
         password: System.fetch_env!("LB_PASS"),
         database: ""
       ]
-
-      if opts[:ssl] == true do
-        :ssl.start()
-      end
 
       {:ok, conn} = Kino.start_child({Postgrex, opts})\
       """


### PR DESCRIPTION
This PR adds toggle to enable SSL connections for Postgres and MySQL

![CleanShot 2023-08-29 at 15 53 33@2x](https://github.com/livebook-dev/kino_db/assets/22266/95b0cd4c-bda8-4b81-8bcc-34f953ba61fc)

If the toggle is enabled `ssl: true` is passed to the database connection options.

Please provide any feedback, in particular on these areas:
* The SSL toggle is **off** by default. This both maintains the current behaviour of the connection cell, and will also support connections to databases with no SSL configured (likely commonplace in local environments)
* The SSL connection requires the `:ssl` application to be started which is done by conditionally calling `:ssl.start()`. Not sure if there is a better approach here.


