### PR TITLE
Fix bug related to sqlserver options

### DIFF
--- a/lib/kino_db/connection_cell.ex
+++ b/lib/kino_db/connection_cell.ex
@@ -357,12 +357,11 @@ defmodule KinoDB.ConnectionCell do
   defp sqlserver_options(attrs) do
     instance = attrs["instance"]
 
-    _opts =
-      if instance && instance != "" do
-        [instance: instance]
-      else
-        []
-      end
+    if instance && instance != "" do
+      [instance: instance]
+    else
+      []
+    end
   end
 
   defp quoted_var(string), do: {String.to_atom(string), [], nil}

--- a/lib/kino_db/connection_cell.ex
+++ b/lib/kino_db/connection_cell.ex
@@ -244,18 +244,10 @@ defmodule KinoDB.ConnectionCell do
   end
 
   defp to_quoted(%{"type" => "sqlserver"} = attrs) do
-    if sqlserver_options?(attrs) do
-      quote do
-        opts = unquote(shared_options(attrs)) ++ unquote(sqlserver_options(attrs))
+    quote do
+      opts = unquote(shared_options(attrs) ++ sqlserver_options(attrs))
 
-        {:ok, unquote(quoted_var(attrs["variable"]))} = Kino.start_child({Tds, opts})
-      end
-    else
-      quote do
-        opts = unquote(shared_options(attrs))
-
-        {:ok, unquote(quoted_var(attrs["variable"]))} = Kino.start_child({Tds, opts})
-      end
+      {:ok, unquote(quoted_var(attrs["variable"]))} = Kino.start_child({Tds, opts})
     end
   end
 
@@ -362,20 +354,10 @@ defmodule KinoDB.ConnectionCell do
     end
   end
 
-  defp sqlserver_options?(attrs) do
-    instance = attrs["instance"]
-
-    if instance && instance != "" do
-      true
-    else
-      false
-    end
-  end
-
   defp sqlserver_options(attrs) do
     instance = attrs["instance"]
 
-    _opts =
+    opts =
       if instance && instance != "" do
         [instance: instance]
       else

--- a/lib/kino_db/connection_cell.ex
+++ b/lib/kino_db/connection_cell.ex
@@ -244,10 +244,18 @@ defmodule KinoDB.ConnectionCell do
   end
 
   defp to_quoted(%{"type" => "sqlserver"} = attrs) do
-    quote do
-      opts = unquote(shared_options(attrs)) ++ unquote(sqlserver_options(attrs))
+    if sqlserver_options?(attrs) do
+      quote do
+        opts = unquote(shared_options(attrs)) ++ unquote(sqlserver_options(attrs))
 
-      {:ok, unquote(quoted_var(attrs["variable"]))} = Kino.start_child({Tds, opts})
+        {:ok, unquote(quoted_var(attrs["variable"]))} = Kino.start_child({Tds, opts})
+      end
+    else
+      quote do
+        opts = unquote(shared_options(attrs))
+
+        {:ok, unquote(quoted_var(attrs["variable"]))} = Kino.start_child({Tds, opts})
+      end
     end
   end
 
@@ -354,17 +362,25 @@ defmodule KinoDB.ConnectionCell do
     end
   end
 
+  defp sqlserver_options?(attrs) do
+    instance = attrs["instance"]
+
+    if instance && instance != "" do
+      true
+    else
+      false
+    end
+  end
+
   defp sqlserver_options(attrs) do
     instance = attrs["instance"]
 
-    opts =
+    _opts =
       if instance && instance != "" do
         [instance: instance]
       else
         []
       end
-
-    opts ++ [ssl: Map.has_key?(attrs, "use_ssl")]
   end
 
   defp quoted_var(string), do: {String.to_atom(string), [], nil}

--- a/lib/kino_db/connection_cell.ex
+++ b/lib/kino_db/connection_cell.ex
@@ -357,7 +357,7 @@ defmodule KinoDB.ConnectionCell do
   defp sqlserver_options(attrs) do
     instance = attrs["instance"]
 
-    opts =
+    _opts =
       if instance && instance != "" do
         [instance: instance]
       else


### PR DESCRIPTION
When we toggle the SSL option for SQL server:

![CleanShot 2023-09-13 at 10 15 52](https://github.com/livebook-dev/kino_db/assets/2719/1c96aa18-c8ef-45b0-84e4-999891c54ca5)

The generated code was wrongly adding SSL twice:

![CleanShot 2023-09-13 at 10 16 00](https://github.com/livebook-dev/kino_db/assets/2719/af93eb59-4390-4115-8d89-86b217a71163)

This PR fixes that bug.
