### PR TITLE
added support to duckdb via ADBC

### DIFF
--- a/lib/assets/connection_cell/main.js
+++ b/lib/assets/connection_cell/main.js
@@ -311,6 +311,40 @@ export function init(ctx, info) {
         v-model="fields.database_path"
         inputClass="input"
         :grow
+      />
+    </div>
+    `,
+  };
+
+
+  const DuckDBForm = {
+    name: "DuckDBForm",
+
+    components: {
+      BaseInput: BaseInput,
+    },
+
+    props: {
+      databasePathValue: {
+        type: String,
+        default: ":memory:",
+      },
+      fields: {
+        type: Object,
+        default: {},
+      }
+    },
+
+    template: `
+    <div class="row">
+      <BaseInput
+        name="database_path"
+        label="Database Path"
+        type="text"
+        :value="databasePathValue"
+        v-model="fields.database_path"
+        inputClass="input"
+        :grow
         :required
       />
     </div>
@@ -622,7 +656,7 @@ export function init(ctx, info) {
         event.preventDefault();
       },
 
-      dragLeave(_) {},
+      dragLeave(_) { },
 
       drop(event) {
         event.preventDefault();
@@ -752,6 +786,7 @@ export function init(ctx, info) {
       BaseInput: BaseInput,
       BaseSelect: BaseSelect,
       SQLiteForm: SQLiteForm,
+      DuckDBForm: DuckDBForm,
       SnowflakeForm: SnowflakeForm,
       DefaultSQLForm: DefaultSQLForm,
       SQLServerForm: SQLServerForm,
@@ -789,6 +824,7 @@ export function init(ctx, info) {
           </div>
 
           <SQLiteForm v-bind:fields="fields" v-if="isSQLite" />
+          <DuckDBForm v-bind:fields="fields" v-if="isDuckDB" />
           <SnowflakeForm v-bind:fields="fields" v-if="isSnowflake" />
           <BigQueryForm v-bind:fields="fields" v-bind:helpBox="helpBox" v-if="isBigQuery" />
           <AthenaForm v-bind:fields="fields" v-bind:helpBox="helpBox" v-bind:hasAwsCredentials="hasAwsCredentials" v-if="isAthena" />
@@ -809,6 +845,7 @@ export function init(ctx, info) {
           { label: "PostgreSQL", value: "postgres" },
           { label: "MySQL", value: "mysql" },
           { label: "SQLite", value: "sqlite" },
+          { label: "DuckDB", value: "duckdb" },
           { label: "Google BigQuery", value: "bigquery" },
           { label: "AWS Athena", value: "athena" },
           { label: "Snowflake", value: "snowflake" },
@@ -820,6 +857,10 @@ export function init(ctx, info) {
     computed: {
       isSQLite() {
         return this.fields.type === "sqlite";
+      },
+
+      isDuckDB() {
+        return this.fields.type === "duckdb";
       },
 
       isSnowflake() {

--- a/lib/assets/connection_cell/main.js
+++ b/lib/assets/connection_cell/main.js
@@ -325,10 +325,6 @@ export function init(ctx, info) {
     },
 
     props: {
-      databasePathValue: {
-        type: String,
-        default: ":memory:",
-      },
       fields: {
         type: Object,
         default: {},
@@ -339,13 +335,11 @@ export function init(ctx, info) {
     <div class="row">
       <BaseInput
         name="database_path"
-        label="Database Path"
+        label="Database Path (in-memory by default)"
         type="text"
-        :value="databasePathValue"
         v-model="fields.database_path"
         inputClass="input"
         :grow
-        :required
       />
     </div>
     `,

--- a/lib/kino_db/connection_cell.ex
+++ b/lib/kino_db/connection_cell.ex
@@ -236,16 +236,15 @@ defmodule KinoDB.ConnectionCell do
   defp to_quoted(%{"type" => "duckdb"} = attrs) do
     var = quoted_var(attrs["variable"])
 
+    opts =
+      case attrs["database_path"] do
+        "" -> [driver: :duckdb]
+        path -> [driver: :duckdb, path: path]
+      end
+
     quote do
       :ok = Adbc.download_driver!(:duckdb)
-
-      adbc_db_conf =
-        case unquote(attrs["database_path"]) do
-          "" -> {Adbc.Database, driver: :duckdb}
-          path -> {Adbc.Database, driver: :duckdb, path: path}
-        end
-
-      {:ok, db} = Kino.start_child(adbc_db_conf)
+      {:ok, db} = Kino.start_child({Adbc.Database, unquote(opts)})
       {:ok, unquote(var)} = Kino.start_child({Adbc.Connection, database: db})
     end
   end

--- a/lib/kino_db/connection_cell.ex
+++ b/lib/kino_db/connection_cell.ex
@@ -235,12 +235,17 @@ defmodule KinoDB.ConnectionCell do
 
   defp to_quoted(%{"type" => "duckdb"} = attrs) do
     var = quoted_var(attrs["variable"])
-    path = quoted_var(attrs["database_path"])
 
     quote do
       :ok = Adbc.download_driver!(:duckdb)
-      path = unquote(attrs["database_path"])
-      {:ok, db} = Kino.start_child({Adbc.Database, driver: :duckdb, path: path})
+
+      adbc_db_conf =
+        case unquote(attrs["database_path"]) do
+          "" -> {Adbc.Database, driver: :duckdb}
+          path -> {Adbc.Database, driver: :duckdb, path: path}
+        end
+
+      {:ok, db} = Kino.start_child(adbc_db_conf)
       {:ok, unquote(var)} = Kino.start_child({Adbc.Connection, database: db})
     end
   end

--- a/lib/kino_db/connection_cell.ex
+++ b/lib/kino_db/connection_cell.ex
@@ -402,7 +402,7 @@ defmodule KinoDB.ConnectionCell do
       Code.ensure_loaded?(Exqlite) -> "sqlite"
       Code.ensure_loaded?(ReqBigQuery) -> "bigquery"
       Code.ensure_loaded?(ReqAthena) -> "athena"
-      Code.ensure_loaded?(Adbc) -> "snowflake"
+      Code.ensure_loaded?(Adbc) -> "duckdb"
       Code.ensure_loaded?(Tds) -> "sqlserver"
       true -> "postgres"
     end

--- a/lib/kino_db/connection_cell.ex
+++ b/lib/kino_db/connection_cell.ex
@@ -163,7 +163,7 @@ defmodule KinoDB.ConnectionCell do
           ~w|database_path|
 
         "duckdb" ->
-          ~w|database_path|
+          []
 
         "bigquery" ->
           ~w|project_id|
@@ -235,6 +235,8 @@ defmodule KinoDB.ConnectionCell do
 
   defp to_quoted(%{"type" => "duckdb"} = attrs) do
     var = quoted_var(attrs["variable"])
+    path = quoted_var(attrs["database_path"])
+    IO.inspect(path)
 
     quote do
       :ok = Adbc.download_driver!(:duckdb)
@@ -400,7 +402,7 @@ defmodule KinoDB.ConnectionCell do
       Code.ensure_loaded?(Exqlite) -> "sqlite"
       Code.ensure_loaded?(ReqBigQuery) -> "bigquery"
       Code.ensure_loaded?(ReqAthena) -> "athena"
-      Code.ensure_loaded?(Adbc) -> "duckdb"
+      Code.ensure_loaded?(Adbc) -> "snowflake"
       Code.ensure_loaded?(Tds) -> "sqlserver"
       true -> "postgres"
     end

--- a/lib/kino_db/connection_cell.ex
+++ b/lib/kino_db/connection_cell.ex
@@ -237,7 +237,7 @@ defmodule KinoDB.ConnectionCell do
     var = quoted_var(attrs["variable"])
 
     opts =
-      case attrs["database_path"] do
+      case String.trim(attrs["database_path"]) do
         "" -> [driver: :duckdb]
         path -> [driver: :duckdb, path: path]
       end

--- a/lib/kino_db/connection_cell.ex
+++ b/lib/kino_db/connection_cell.ex
@@ -236,7 +236,6 @@ defmodule KinoDB.ConnectionCell do
   defp to_quoted(%{"type" => "duckdb"} = attrs) do
     var = quoted_var(attrs["variable"])
     path = quoted_var(attrs["database_path"])
-    IO.inspect(path)
 
     quote do
       :ok = Adbc.download_driver!(:duckdb)

--- a/lib/kino_db/sql_cell.ex
+++ b/lib/kino_db/sql_cell.ex
@@ -220,6 +220,10 @@ defmodule KinoDB.SQLCell do
     to_explorer_quoted(attrs, fn n -> "?#{n}" end)
   end
 
+  defp to_quoted(%{"connection" => %{"type" => "duckdb"}} = attrs) do
+    to_explorer_quoted(attrs, fn n -> "?#{n}" end)
+  end
+
   # Req-based
   defp to_quoted(%{"connection" => %{"type" => "bigquery"}} = attrs) do
     to_req_quoted(attrs, fn _n -> "?" end, :bigquery)
@@ -362,7 +366,7 @@ defmodule KinoDB.SQLCell do
     end
   end
 
-  defp missing_dep(%{type: "snowflake"}) do
+  defp missing_dep(%{type: adbc}) when adbc in ~w[snowflake duckdb] do
     unless Code.ensure_loaded?(Explorer) do
       ~s|{:explorer, "~> 0.8"}|
     end


### PR DESCRIPTION
In my role as Data Engineer I've been moving out from dataframes (aka spark) as I'm building everything with DBT and BigQuery and locally with DuckDB (CLI). Using just sql to build different stages (kind of delta lake), has been a great way to facilitate the work of data scientists and for data governance. 

I can see how DuckDB could work as the Ingestion and transformation layer to expose a simplified and maybe materialized "data marts" to explorer or vegalite. This is so powerful!

Amazing work with ADBC ! 