### PR TITLE
Fix DuckDB label

### DIFF
--- a/lib/assets/sql_cell/main.js
+++ b/lib/assets/sql_cell/main.js
@@ -262,7 +262,8 @@ export function init(ctx, payload) {
           bigquery: "Google BigQuery",
           athena: "AWS Athena",
           snowflake: "Snowflake",
-          sqlserver: "SQL Server"
+          sqlserver: "SQL Server",
+          duckdb: "DuckDB"
         },
       };
     },


### PR DESCRIPTION
After we merged the integration with DuckDB, the label inside the connection selector of the SQL Query Smart cell had a problem.

## Before

![CleanShot 2024-05-15 at 13 57 00](https://github.com/livebook-dev/kino_db/assets/2719/076b1d3a-a8f6-4f77-bf23-fd2285ba9699)

## After

![CleanShot 2024-05-15 at 13 58 57](https://github.com/livebook-dev/kino_db/assets/2719/ec5b85b5-bed1-444c-b798-5ae245c8bd38)
