### PR TITLE
Fix SQL cell to keep the selected connection when not in binding

### DIFF
--- a/lib/kino_db/sql_cell.ex
+++ b/lib/kino_db/sql_cell.ex
@@ -142,13 +142,8 @@ defmodule KinoDB.SQLCell do
 
   defp search_connection([connection | _], nil), do: connection
 
-  defp search_connection([], connection), do: connection
-
-  defp search_connection(connections, %{variable: variable}) do
-    case Enum.find(connections, &(&1.variable == variable)) do
-      nil -> List.first(connections)
-      connection -> connection
-    end
+  defp search_connection(connections, connection) do
+    Enum.find(connections, connection, &(&1.variable == connection.variable))
   end
 
   @compile {:no_warn_undefined, {DBConnection, :connection_module, 1}}


### PR DESCRIPTION
Scenario:

```
[Connection cell: conn1]
[Connection cell: conn2]
[SQL cell: using conn2]
```

Let's say we restart the runtime and evaluate the first connection cell. Currently, the SQL cell would pick up `conn1` and even starting the second connection wouldn't roll that back.

This is a regression from #2. The corresponding change was made to update the selected database type, in case the user changes the connection cell to use different database and assigns into the same variable name.

I added tests for both #2 and the regression :)